### PR TITLE
feature/ 인증인가 구현 + 로그인 아이디와 동일한 게시글, 댓글에만 수정삭제 보이도록 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["resave"]
+  "cSpell.words": ["commonheader", "resave"]
 }

--- a/be-server/controllers/posts.controller.js
+++ b/be-server/controllers/posts.controller.js
@@ -21,7 +21,6 @@ const getPosts = (req, res) => {
 // 게시글 상세 페이지
 const getPost = (req, res) => {
   const postId = req.params.postId;
-  const { id } = req.session.user;
   fs.readFile(filePostsPath, "utf-8", (err, data) => {
     if (err) {
       return res.status(500).send("게시글 불러오기에 실패했습니다.");
@@ -34,16 +33,13 @@ const getPost = (req, res) => {
       post.hits = Number(post.hits) + 1; // 조회수 증가
     }
 
-    // 게시글 작성자와 로그인한 사용자가 같은 경우 active 속성을 true로 설정
-    const active = post.user_id === id;
-
     console.log(post);
     // 업데이트된 게시글 정보를 파일에 저장
     fs.writeFile(filePostsPath, JSON.stringify(posts, null, 2), (err) => {
       if (err) {
         return res.status(500).send("조회수 업데이트에 실패했습니다.");
       }
-      res.json({ post, active });
+      res.json(post);
     });
   });
 };

--- a/be-server/controllers/posts.controller.js
+++ b/be-server/controllers/posts.controller.js
@@ -21,6 +21,7 @@ const getPosts = (req, res) => {
 // 게시글 상세 페이지
 const getPost = (req, res) => {
   const postId = req.params.postId;
+  const { id } = req.session.user;
   fs.readFile(filePostsPath, "utf-8", (err, data) => {
     if (err) {
       return res.status(500).send("게시글 불러오기에 실패했습니다.");
@@ -33,14 +34,16 @@ const getPost = (req, res) => {
       post.hits = Number(post.hits) + 1; // 조회수 증가
     }
 
+    // 게시글 작성자와 로그인한 사용자가 같은 경우 active 속성을 true로 설정
+    const active = post.user_id === id;
+
     console.log(post);
     // 업데이트된 게시글 정보를 파일에 저장
     fs.writeFile(filePostsPath, JSON.stringify(posts, null, 2), (err) => {
       if (err) {
         return res.status(500).send("조회수 업데이트에 실패했습니다.");
       }
-
-      res.json(post);
+      res.json({ post, active });
     });
   });
 };

--- a/fe-server/app.js
+++ b/fe-server/app.js
@@ -45,7 +45,7 @@ app.get("/main/edit/post", (req, res) => {
 
 app.get("/users/editprofile", (req, res) => {
   // 프로필 수정
-  res.sendFile(path.join(__dirname, "public/html/profile.html"));
+  res.sendFile(path.join(__dirname, "public/html/editprofile.html"));
 });
 
 app.get("/users/editpwd", (req, res) => {

--- a/fe-server/public/css/post.css
+++ b/fe-server/public/css/post.css
@@ -81,13 +81,18 @@ main {
 
 .inner .title .control .controlBtns,
 .inner .comments .right .controlBtns {
+  display: none;
   width: 128px;
   height: 64px;
   margin-right: 16px;
-  display: flex;
   gap: 8px;
   justify-content: center;
   align-items: center;
+}
+
+.inner .title .control .controlBtns.active,
+.inner .comments .right .controlBtns.active {
+  display: flex;
 }
 
 .inner .title .control .controlBtns button,

--- a/fe-server/public/html/editpost.html
+++ b/fe-server/public/html/editpost.html
@@ -24,7 +24,7 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/makepost.css" />
-    <script defer src="/js/commonheader.js"></script>
+    <script defer type="module" src="/js/commonheader.js"></script>
     <script type="module" src="/js/editpost.js"></script>
   </head>
   <body>

--- a/fe-server/public/html/editprofile.html
+++ b/fe-server/public/html/editprofile.html
@@ -24,7 +24,7 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/editprofile.css" />
-    <script defer src="/js/commonheader.js"></script>
+    <script defer type="module" src="/js/commonheader.js"></script>
     <script defer type="module" src="/js/editprofile.js"></script>
   </head>
   <body>

--- a/fe-server/public/html/editpwd.html
+++ b/fe-server/public/html/editpwd.html
@@ -24,7 +24,7 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/editprofile.css" />
-    <script defer src="/js/commonheader.js"></script>
+    <script defer type="module" src="/js/commonheader.js"></script>
     <script defer type="module" src="/js/editpwd.js"></script>
   </head>
   <body>

--- a/fe-server/public/html/makepost.html
+++ b/fe-server/public/html/makepost.html
@@ -24,7 +24,7 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/makepost.css" />
-    <script defer src="/js/commonheader.js"></script>
+    <script defer type="module" src="/js/commonheader.js"></script>
     <script defer type="module" src="/js/makepost.js"></script>
   </head>
   <body>

--- a/fe-server/public/html/post.html
+++ b/fe-server/public/html/post.html
@@ -24,7 +24,7 @@
     />
     <link rel="stylesheet" href="/css/common.css" />
     <link rel="stylesheet" href="/css/post.css" />
-    <script defer src="/js/commonheader.js"></script>
+    <script defer type="module" src="/js/commonheader.js"></script>
     <script defer type="module" src="/js/post.js"></script>
   </head>
   <body>

--- a/fe-server/public/js/commonheader.js
+++ b/fe-server/public/js/commonheader.js
@@ -4,8 +4,6 @@ const menuEl = document.querySelector(".menu");
 const logoutEl = document.querySelector(".menu .logout");
 const profileImgEl = document.querySelector("header div.profile div");
 
-let userData = null; // 전역 변수로 사용자 데이터를 캐시
-
 // 프로필 이미지  가져오기
 export const getProfileImg = async () => {
   if (userData) {
@@ -24,7 +22,6 @@ export const getProfileImg = async () => {
       .pop()}`;
     console.log(profileLink);
     profileImgEl.style.backgroundImage = `url('${profileLink}')`;
-    userData = data; // 사용자 데이터를 캐시에 저장
     return data;
   }
 };

--- a/fe-server/public/js/commonheader.js
+++ b/fe-server/public/js/commonheader.js
@@ -4,8 +4,15 @@ const menuEl = document.querySelector(".menu");
 const logoutEl = document.querySelector(".menu .logout");
 const profileImgEl = document.querySelector("header div.profile div");
 
+let userData = null; // 전역 변수로 사용자 데이터를 캐시
+
 // 프로필 이미지  가져오기
-const getProfileImg = async () => {
+export const getProfileImg = async () => {
+  if (userData) {
+    console.log("cached data");
+    return userData; // 이미 데이터가 있으면 캐시된 데이터 반환
+  }
+  console.log("not cached data1");
   const response = await fetch(`http://localhost:4000/users/profile`, {
     method: "GET",
     credentials: "include", // 쿠키를 요청과 함께 보내도록 설정
@@ -17,6 +24,8 @@ const getProfileImg = async () => {
       .pop()}`;
     console.log(profileLink);
     profileImgEl.style.backgroundImage = `url('${profileLink}')`;
+    userData = data; // 사용자 데이터를 캐시에 저장
+    return data;
   }
 };
 

--- a/fe-server/public/js/post.js
+++ b/fe-server/public/js/post.js
@@ -27,28 +27,30 @@ fetch(`http://localhost:4000/posts/${postId}`, {
   });
 
 const renderPost = (postData, container) => {
+  console.log(postData, postData.post, postData.active);
   let postImgLink = "";
   if (
-    postData.attach_file_path &&
-    postData.attach_file_path !== "http://localhost:4000/"
+    postData.post.attach_file_path &&
+    postData.post.attach_file_path !== "http://localhost:4000/"
   ) {
-    postImgLink = `http://localhost:4000/post/${postData.attach_file_path
+    postImgLink = `http://localhost:4000/post/${postData.post.attach_file_path
       .split("/")
       .pop()}`;
   }
   console.log(postImgLink);
   container.innerHTML = `
     <div class="title">
-      <h2>${postData.post_title}</h2>
+      <h2>${postData.post.post_title}</h2>
       <div class="control">
         <div class="writer">
           <div class="img"><div style="background-image: url('${
-            postData.profileImagePath
+            postData.post.profileImagePath
           }');"></div></div>
-          <div class="name">${postData.nickname}</div>
-          <div class="date">${formatDate(postData.created_at)}</div>
+          <div class="name">${postData.post.nickname}</div>
+          <div class="date">${formatDate(postData.post.created_at)}</div>
         </div>
-        <div class="controlBtns">
+        
+        <div class="controlBtns ${postData.active ? "active" : ""}">
           <button class="modi">수정</a></button>
           <button class="del"><a href="#">삭제</a></button>
         </div>
@@ -60,16 +62,19 @@ const renderPost = (postData, container) => {
         ? `<div class="img" style="background-image: url('${postImgLink}')"></div>`
         : ""
     }
-    <div class="texts">${postData.post_content.replace(/\n/g, "<br>")}</div>
+    <div class="texts">${postData.post.post_content.replace(
+      /\n/g,
+      "<br>"
+    )}</div>
     </div>
 
     <div class="clickBtn">
       <button class="views">
-        <p class="count">${changeNum(postData.hits)}</p>
+        <p class="count">${changeNum(postData.post.hits)}</p>
         <p class="text">조회수</p>
       </button>
       <button class="comments">
-        <p class="count">${changeNum(postData.like)}</p>
+        <p class="count">${changeNum(postData.post.like)}</p>
         <p class="text">좋아요</p>
       </button>
     </div>
@@ -88,8 +93,8 @@ const renderPost = (postData, container) => {
   </div>
     <div class="commentsList">
     ${
-      postData.comments && postData.comments.length > 0
-        ? postData.comments
+      postData.post.comments && postData.post.comments.length > 0
+        ? postData.post.comments
             .map(
               (comment) => `
       <div class="comments ${comment.comment_id}">
@@ -196,7 +201,7 @@ const afterRender = (data) => {
 
   // 게시글 수정 버튼 클릭 시 게시글 수정 페이지로 이동
   modiBtn.addEventListener("click", (event) => {
-    const editUrl = `/main/edit/post?post_id=${data.post_id}`;
+    const editUrl = `/main/edit/post?post_id=${data.post.post_id}`;
     event.preventDefault(); // 기본 이벤트 방지
     console.log("click");
 


### PR DESCRIPTION
feature/ 댓글도 본인댓글만 수정삭제 버튼보이도록 추가.
- 로그인 유저 불러오는 api에 return data 해서 게시글, 댓글의 user_id와 비교
- 이전 게시글 수정삭제 로직도 이 방법으로 다시 바꿔 구현
-> 추가 해결해야하는 문제. commonheader.js에서의 api를 import해서 사용한 방식이라 게시글 상세페이지에서는 해당 api호출이 두번일어나고 있음.

### commonheader.js
```javascript
// 프로필 이미지  가져오기
export const getProfileImg = async () => {
  if (userData) {
    console.log("cached data");
    return userData; // 이미 데이터가 있으면 캐시된 데이터 반환
  }
  console.log("not cached data1");
  const response = await fetch(`http://localhost:4000/users/profile`, {
    method: "GET",
    credentials: "include", // 쿠키를 요청과 함께 보내도록 설정
  });
  if (response.status === 200) {
    const data = await response.json();
    const profileLink = `http://localhost:4000/profile/${data.profileImagePath
      .split("/")
      .pop()}`;
    console.log(profileLink);
    profileImgEl.style.backgroundImage = `url('${profileLink}')`;
    return data;
  }
};
```

로그인 유저 정보 불러오는 api 요청 import하여 게시글 과 댓글의 유저 id와 동일한 경우 수정삭제 버튼 보이도록 구현
### post.js
```javascript
import { getProfileImg } from "./commonheader.js";

 사용자 정보 가져오기
document.addEventListener("DOMContentLoaded", async () => {
  const user = await getProfileImg(); // getProfileImg 함수가 완료될 때까지 기다림
  fetchPostData(user); // getProfileImg 완료 후 fetchPostData 실행
});

```

버튼유무는 `.active` 유무에 따라.
```javascript
    <div class="controlBtns ${
          user.user_id === comment.user_id ? "active" : ""
        }" >
          <button class="modi">수정</button>
          <button class="del">삭제</button>
          </div>
```