### PR TITLE
feature/ 회원정보 수정 직후, 게시글/댓글 작성 시 변경된 정보로 등록되도록 구현완

### DIFF
--- a/be-server/controllers/posts.controller.js
+++ b/be-server/controllers/posts.controller.js
@@ -222,7 +222,7 @@ const postComment = (req, res) => {
         return res.status(204).send("댓글 수정 성공");
       });
     } else {
-      // 댓글 추가 요청이 아닌 경우에만 실행
+      // 댓글 수정 요청이 아닌 경우에만 실행
       // 옵셔녈 체이닝 사용 // || : 둘중하나만 참이면 되기 때문에, 참인 경우 처음 등장하는 참값 리턴. 모두 거짓이라면 마지막 거짓값을 리턴.  (거짓의 기준 : false인 모든 값)
       const lastCommentId =
         post.comments[post.comments.length - 1]?.comment_id || 0;

--- a/be-server/controllers/users.controller.js
+++ b/be-server/controllers/users.controller.js
@@ -168,6 +168,10 @@ const postEditProfile = (req, res) => {
         updated_at: new Date(),
       };
 
+      // 세션 정보 업데이트
+      req.session.user.nickname = nickname;
+      req.session.user.profileImg = newProfileImagePath;
+
       fs.writeFile(fileUsersPath, JSON.stringify(users, null, 2), (err) => {
         if (err) {
           return res.status(500).json({ message: "닉네임 수정 실패" });

--- a/be-server/controllers/users.controller.js
+++ b/be-server/controllers/users.controller.js
@@ -168,14 +168,13 @@ const postEditProfile = (req, res) => {
         updated_at: new Date(),
       };
 
-      // 세션 정보 업데이트
-      req.session.user.nickname = nickname;
-      req.session.user.profileImg = newProfileImagePath;
-
       fs.writeFile(fileUsersPath, JSON.stringify(users, null, 2), (err) => {
         if (err) {
           return res.status(500).json({ message: "닉네임 수정 실패" });
         }
+        // 세션 정보 업데이트
+        req.session.user.nickname = nickname;
+        req.session.user.profileImg = newProfileImagePath;
         return res.status(201).json({ message: "닉네임 수정 성공" });
       });
     });

--- a/fe-server/public/js/commonheader.js
+++ b/fe-server/public/js/commonheader.js
@@ -6,15 +6,16 @@ const profileImgEl = document.querySelector("header div.profile div");
 
 // 프로필 이미지  가져오기
 export const getProfileImg = async () => {
-  if (userData) {
-    console.log("cached data");
-    return userData; // 이미 데이터가 있으면 캐시된 데이터 반환
-  }
-  console.log("not cached data1");
   const response = await fetch(`http://localhost:4000/users/profile`, {
     method: "GET",
     credentials: "include", // 쿠키를 요청과 함께 보내도록 설정
   });
+  if (response.status === 401) {
+    // Unauthorized, 사용자가 로그인되지 않음
+    alert("로그인을 해주세요.");
+    window.location.href = "/"; // 홈이나 로그인 페이지로 리다이렉션
+    return;
+  }
   if (response.status === 200) {
     const data = await response.json();
     const profileLink = `http://localhost:4000/profile/${data.profileImagePath

--- a/fe-server/public/js/editprofile.js
+++ b/fe-server/public/js/editprofile.js
@@ -12,12 +12,6 @@ fetch(`http://localhost:4000/users/profile`, {
   credentials: "include", // 쿠키를 요청과 함께 보내도록 설정
 })
   .then((response) => {
-    if (!response.ok && response.status === 401) {
-      // Unauthorized, 사용자가 로그인되지 않음
-      alert("로그인을 해주세요.");
-      window.location.href = "/"; // 홈이나 로그인 페이지로 리다이렉션
-      return;
-    }
     return response.json();
   })
   .then((data) => {

--- a/fe-server/public/js/main.js
+++ b/fe-server/public/js/main.js
@@ -7,15 +7,7 @@ const posts = [];
 fetch("http://localhost:4000/posts", {
   credentials: "include", // 쿠키를 요청과 함께 보내도록 설정
 })
-  .then((response) => {
-    if (!response.ok && response.status === 401) {
-      // Unauthorized, 사용자가 로그인되지 않음
-      alert("로그인을 해주세요.");
-      window.location.href = "/"; // 홈이나 로그인 페이지로 리다이렉션
-      return;
-    }
-    return response.json();
-  })
+  .then((response) => response.json())
   .then((data) => {
     console.log(data);
     data.forEach((post) => {

--- a/fe-server/public/js/post.js
+++ b/fe-server/public/js/post.js
@@ -10,6 +10,7 @@ console.log(postId);
 // 페이지 로드 시 프로필 이미지 및 사용자 정보 가져오기
 document.addEventListener("DOMContentLoaded", async () => {
   const user = await getProfileImg(); // getProfileImg 함수가 완료될 때까지 기다림
+  console.log(user.user_id, user.nickname);
   fetchPostData(user); // getProfileImg 완료 후 fetchPostData 실행
 });
 
@@ -213,7 +214,7 @@ const afterRender = (data) => {
 
   // 게시글 수정 버튼 클릭 시 게시글 수정 페이지로 이동
   modiBtn.addEventListener("click", (event) => {
-    const editUrl = `/main/edit/post?post_id=${data.post.post_id}`;
+    const editUrl = `/main/edit/post?post_id=${data.post_id}`;
     event.preventDefault(); // 기본 이벤트 방지
     console.log("click");
 


### PR DESCRIPTION
기존 문제 : - ~~회원정보 변경 후 댓글,게시글작성을 하면, 바뀌기 이전 닉네임, 프로필사진으로 등록된다.~~ **해결완료!**
- json에는 변경사항 잘 업데이트 되어있다.
- ~~로그아웃 후 재로그인 할때만 바뀐 프로필로 댓글, 게시글 작성된다.~~**해결완료!**

![해결 전](https://www.notion.so/image/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2F38552da6-340d-42c1-a9a1-b181ff331f03%2Fc96f3ffd-da87-4dbd-8671-d0aad7044af1%2FUntitled.png?table=block&id=747c2ed3-104e-43f1-8dff-8536952ada8d&spaceId=38552da6-340d-42c1-a9a1-b181ff331f03&width=2000&userId=ab397d89-de29-459f-ba18-a91f7b7c35c6&cache=v2)

해결 전

```jsx
 // 회원정보 수정 post 요청에서 
 fs.writeFile(fileUsersPath, JSON.stringify(users, null, 2), (err) => {
        if (err) {
          return res.status(500).json({ message: "닉네임 수정 실패" });
        }
        // 세션 정보 업데이트
        req.session.user.nickname = nickname;
        req.session.user.profileImg = newProfileImagePath;
        return res.status(201).json({ message: "닉네임 수정 성공" });
      });
```

![해결 후](https://www.notion.so/image/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2F38552da6-340d-42c1-a9a1-b181ff331f03%2Fc42403e2-1264-4e89-8e50-16d07950bac5%2FUntitled.png?table=block&id=d16289bd-663c-44b2-8061-6e33a6a0b232&spaceId=38552da6-340d-42c1-a9a1-b181ff331f03&width=2000&userId=ab397d89-de29-459f-ba18-a91f7b7c35c6&cache=v2)

해결 후